### PR TITLE
Marvin should listen on port 80 instead of 8000

### DIFF
--- a/vendor/xssbot/README.md
+++ b/vendor/xssbot/README.md
@@ -6,7 +6,7 @@ _A "performant enough" xss bot for use in CTF challenges._
 
 Marvin is desgined to run as a side-car to your challenge, so each author will need to use it in their individual challenges.
 
-Include the following in your `docker-compose.yml`. By default Marvin listens on port 8000, this can be configured with the `PORT` environmental variable. It may be helpful to expose this port for development.
+Include the following in your `docker-compose.yml`. By default Marvin listens on port 80, it may be worth forwarding a port here for development so you can make calls directly to marvin.
 
 ```yaml
 services:
@@ -17,7 +17,7 @@ services:
     environment:
      - NODE_ENVIRONMENT: development
     port:
-     - 8000:8000
+     - 8000:80
 ```
 
 You can then request Marvin visit pages by sending a POST request to `http://xssbot/visit` from within your dockerized challenge (or `http://localhost:8000/visit` if you are testing locally). The request needs to contain
@@ -41,11 +41,6 @@ requests.post('http://xssbot/visit', json={
 ### Configuration
 
 Marvin takes it's configuration through environmental variables. There are more variables than those documented below, please check out `config.ts` if you _really_ need to change something else.
-
-#### PORT
-_Default_: `8000`
-
-The port the webserver should listen on.
 
 #### OUTBOUND_AUTH_METHOD
 _Default_: `none`

--- a/vendor/xssbot/context/examples/authCookieJar/app.py
+++ b/vendor/xssbot/context/examples/authCookieJar/app.py
@@ -14,7 +14,7 @@ def index():
 
 @app.route('/visit')
 def visit():
-    requests.post('http://marvin:8000/visit', json={
+    requests.post('http://marvin/visit', json={
         'url': 'http://webapp:8000/'
     }, headers={
         'x-ssrf-protection': '1'

--- a/vendor/xssbot/context/examples/authHttpGet/app.py
+++ b/vendor/xssbot/context/examples/authHttpGet/app.py
@@ -21,7 +21,7 @@ def admin():
 
 @app.route('/visit')
 def visit():
-    requests.post('http://marvin:8000/visit', json={
+    requests.post('http://marvin/visit', json={
         'url': 'http://webapp:8000/'
     }, headers={
         'x-ssrf-protection': '1'

--- a/vendor/xssbot/context/examples/requireAuthToMarvin/app.py
+++ b/vendor/xssbot/context/examples/requireAuthToMarvin/app.py
@@ -10,7 +10,7 @@ def index():
 
 @app.route('/visitbad')
 def visitbad():
-    requests.post('http://marvin:8000/visit', json={
+    requests.post('http://marvin/visit', json={
         'url': 'http://webapp:8000/'
     }, headers={
         'x-ssrf-protection': '1'
@@ -19,7 +19,7 @@ def visitbad():
 
 @app.route('/visitgood')
 def visitgood():
-    requests.post('http://marvin:8000/visit', json={
+    requests.post('http://marvin/visit', json={
         'url': 'http://webapp:8000/'
     }, headers={
         'x-ssrf-protection': '1',

--- a/vendor/xssbot/context/examples/simple/app.py
+++ b/vendor/xssbot/context/examples/simple/app.py
@@ -9,7 +9,7 @@ def index():
 
 @app.route('/visit')
 def visit():
-    requests.post('http://marvin:8000/visit', json={
+    requests.post('http://marvin/visit', json={
         'url': 'http://webapp:8000/'
     }, headers={
         'x-ssrf-protection': '1'

--- a/vendor/xssbot/context/supervisord.conf
+++ b/vendor/xssbot/context/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:init]
-command=/bin/bash -c "supervisorctl start redis && supervisorctl start $([ $NODE_ENVIRONMENT == development ] && echo 'marvin_debug' || echo 'marvin')"
+command=/bin/bash -c "iptables-legacy -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 8000 && supervisorctl start redis && supervisorctl start $([ $NODE_ENVIRONMENT == development ] && echo 'marvin_debug' || echo 'marvin')"
 autoresetart=false
 
 [program:marvin_debug]

--- a/vendor/xssbot/dockerfiles/Dockerfile.chrome
+++ b/vendor/xssbot/dockerfiles/Dockerfile.chrome
@@ -16,7 +16,7 @@ FROM base as dist
 
 # hadolint ignore=DL3015,DL4006
 RUN apt-get update \
- && apt-get install -y wget gnupg ca-certificates redis-server supervisor \
+ && apt-get install -y wget gnupg ca-certificates redis-server supervisor iptables \
  && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
  && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
  && apt-get update \


### PR DESCRIPTION
Marvin exposes port 80 so people can post to `http://marvin/visit` instead of `http://marvin:8000/visit`