### PR TITLE
Update README with ALLOW_INTERNAL_ADDDRESS Var

### DIFF
--- a/vendor/xssbot/README.md
+++ b/vendor/xssbot/README.md
@@ -163,7 +163,7 @@ requests.post('...', json=..., headers={
 })
 ```
 
-#### ALLOW_INTERNAL_ADDRESSES
+#### ALLOW_INTERNAL_ADDRESS
 _Default_: `false`
 
 Allows request to be made to loopback and link-local addresses, typically this is not allowed. Private addresses are not effected by this.


### PR DESCRIPTION
Actual implementation is ALLOW_INTERNAL_ADDRESS not ALLOW_INTERNAL_ADDRESSES

we should change the code. But updating the readme for now for backwards compat

https://github.com/DownUnderCTF/docker-vendor/blob/7d9e7ff8a5db255e7e745ee88250a18ed2237b11/vendor/xssbot/context/marvin/config.ts#L39